### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ hitting `<F10>` will close that window rather than any auxiliary ones.
 
 In other words, the smart auxiliary windows closing feature is delayed about 1 sec. This way you
 can move into a regular window you want to close, press `<F10>` immediately, and close it even if
-there are open auxilary windows on the screen. The delay can be adjusted or even disabled.
+there are open auxiliary windows on the screen. The delay can be adjusted or even disabled.
 
 Usage
 -----


### PR DESCRIPTION
szw, I've corrected a typographical error in the documentation of the [vim-smartclose](https://github.com/szw/vim-smartclose) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
